### PR TITLE
SPSC: Relaxed load if value is only written in same thread

### DIFF
--- a/src/bounded/spsc.rs
+++ b/src/bounded/spsc.rs
@@ -156,7 +156,7 @@ impl<T> Queue<T> {
         }
 
         // Return an error if the queue is full.
-        let write = self.write.load(Acquire);
+        let write = self.write.load(Relaxed);
         if write.wrapping_sub(self.read_copy.get()) == self.buffer.size() {
             self.read_copy.set(self.read.load(Acquire));
             if write.wrapping_sub(self.read_copy.get()) == self.buffer.size() {
@@ -172,7 +172,7 @@ impl<T> Queue<T> {
 
     fn consume(&self) -> Result<T, ConsumeError> {
         // Return an error if the queue is empty.
-        let read = self.read.load(Acquire);
+        let read = self.read.load(Relaxed);
         if read == self.write_copy.get() {
             self.write_copy.set(self.write.load(Acquire));
             if read == self.write_copy.get() {


### PR DESCRIPTION
The write index is only ever written by the producer thread, therefore there is no need for synchronization when reading it again from the producer thread.

Same for the read index and the consumer thread.

Loads for values written from the other thread still need `Acquire`.